### PR TITLE
Downgrade durable task plugin

### DIFF
--- a/jenkins/plugins.txt
+++ b/jenkins/plugins.txt
@@ -45,7 +45,7 @@ dark-theme:0.0.5
 display-url-api:2.3.3
 docker-commons:1.17
 docker-workflow:1.23
-durable-task:1.34
+durable-task:1.33
 extended-choice-parameter:0.78
 extended-read-permission:3.2
 external-monitor-job:1.7


### PR DESCRIPTION
### JIRA link (if applicable) ###



### Change description ###

Testing if 

https://github.com/jenkinsci/durable-task-plugin/commit/835174dafe10b3f129c2af05829c05b9d89c278c

has introduced a regression in this fix:

https://issues.jenkins-ci.org/browse/JENKINS-58290

as we are currently affected by it in the docker agent builds.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
