### PR TITLE
Don't separate major / minor versions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "enabledManagers": ["jenkins"],
   "automerge": true,
-  "requiredStatusChecks": null,
+  "separateMajorMinor": false,
   "groupName": "all"
 }


### PR DESCRIPTION
Renovate mis-detects Jenkins plugins with a continuous delivery version scheme as a major update, stop separating them out to reduce the PRs...

`requiredStatusChecks` is no longer needed because we have CI on the repo now