### PR TITLE
Manage new detached plugin as code

### DIFF
--- a/jenkins/plugins.txt
+++ b/jenkins/plugins.txt
@@ -66,6 +66,7 @@ handlebars:3.0.8
 handy-uri-templates-2-api:2.1.8-22.v77d5b_75e6953
 htmlpublisher:1.30
 http_request:1.15
+instance-identity:116.vf8f487400980
 jackson2-api:2.13.3-285.vc03c0256d517
 jacoco:3.3.2
 jaxb:2.3.6-1


### PR DESCRIPTION
Outdated plugin I noticed on prod, needs to be managed as code