### PR TITLE
Revert "Update dependency lockable-resources to v1228"

### DIFF
--- a/jenkins/plugins.txt
+++ b/jenkins/plugins.txt
@@ -79,7 +79,7 @@ junit:1252.vfc2e5efa_294f
 kubernetes-client-api:6.9.2-239.ve49a_3f285167
 kubernetes-credentials:0.11
 kubernetes:4174.v4230d0ccd951
-lockable-resources:1228.v1b_2379444670
+lockable-resources:1224.v5e9500f98269
 mailer:463.vedf8358e006b_
 matrix-auth:3.2.1
 matrix-project:822.v01b_8c85d16d2


### PR DESCRIPTION
Experiencing issues on CFT Jenkins where this has updated - there haven't been any issues with lockable-resources on SDS Jenkins which is still on 1224, want to roll this upgrade back and review.

Reverts hmcts/cnp-jenkins-docker#1308