### PR TITLE
Revert "Update dependency github-scm-filter-aged-refs to v55"

### DIFF
--- a/jenkins/plugins.txt
+++ b/jenkins/plugins.txt
@@ -60,7 +60,7 @@ github-branch-source:1803.v98e3d8a_c8169
 github-checks:589.v845136f916cd
 github:1.40.0
 github-scm-trait-notification-context:40.vfa_7f31a_b_d7f8
-github-scm-filter-aged-refs:55.v9d01cee685e4
+github-scm-filter-aged-refs:47.v5450b_74d684c
 handy-uri-templates-2-api:2.1.8-30.v7e777411b_148
 htmlpublisher:1.36
 http_request:1.19


### PR DESCRIPTION
Reverts hmcts/cnp-jenkins-docker#1522

[DTSPO-19576](https://tools.hmcts.net/jira/browse/DTSPO-19576)

Danny tested here to confirm it was the issue cause: https://github.com/hmcts/cnp-flux-config/commit/77d9282a320ede736420a31b9edf4044e2795435

Reverting for now until we look into cause and get correct config for future.
