### PR TITLE
Renovate: ignoreDeps scm-filter-aged-refs due to issues in v55

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,5 +5,6 @@
   ],
   "separateMajorMinor": false,
   "groupName": "all",
-  "schedule": "before 6am every weekday"
+  "schedule": "before 6am every weekday",
+  "ignoreDeps": ["github-scm-filter-aged-refs"]
 }


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-19576


### Change description

- temporarily remove scm-filter-aged-refs from renovate as either new version v55/current config with new version causing issues in ticket above ^



### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
