### PR TITLE
Ignoredeps azure-vm-agents till after xmas (breaking Jenkins agents)

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,5 +6,5 @@
   "separateMajorMinor": false,
   "groupName": "all",
   "schedule": "before 6am every weekday",
-  "ignoreDeps": ["github-scm-filter-aged-refs", "azure-vm-agents", "jenkins/jenkins", "kubernetes", "workflow-cps"]
+  "ignoreDeps": ["github-scm-filter-aged-refs", "azure-vm-agents"]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,5 +6,5 @@
   "separateMajorMinor": false,
   "groupName": "all",
   "schedule": "before 6am every weekday",
-  "ignoreDeps": ["github-scm-filter-aged-refs"]
+  "ignoreDeps": ["github-scm-filter-aged-refs", "azure-vm-agents", "jenkins/jenkins", "kubernetes", "workflow-cps"]
 }

--- a/jenkins/plugins.txt
+++ b/jenkins/plugins.txt
@@ -8,7 +8,7 @@ azure-cosmosdb:2.v738e7ec0eeea_
 azure-credentials:343.vd80f9c4859df
 azure-keyvault:251.vcfe31c013dc7
 azure-sdk:191.v53ec8913ee10
-azure-vm-agents:984.v3684c515c3d5
+azure-vm-agents:976.v3a_c9c21e1505
 basic-branch-build-strategies:190.v343a_ee70d920
 blueocean-autofavorite:1.2.5
 blueocean-bitbucket-pipeline:1.27.16


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-23036


### Change description

- ignore azure-vm-agents as seems to be breaking Jenkins build agent pools



### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
