### PR TITLE
Downgrade sauce on demand

### DIFF
--- a/jenkins/plugins.txt
+++ b/jenkins/plugins.txt
@@ -107,7 +107,7 @@ plugin-util-api:6.1167.v022176c7e0ca_
 pubsub-light:1.19
 run-condition:243.v3c3f94e46a_8b_
 saml:4.583.vc68232f7018a_
-sauce-ondemand:2.2.0
+sauce-ondemand:1.215
 scm-api:707.v749f968369d4
 script-security:1378.vf25626395f49
 slack:795.v4b_9705b_e6d47


### PR DESCRIPTION
### Change description

There's an API timeout happening with sauce-on-demand which seems to be linked to v2.
Testing a downgrade to v1 to see if that helps unblock us for now.

### Security Vulnerability Assessment ###

_Not that I'm aware of but this is an older version so it may have older dependencies_

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
