### PR TITLE
DTSPO-33801: Add prometheus plugin for controller health metrics

### DIFF
--- a/jenkins/plugins.txt
+++ b/jenkins/plugins.txt
@@ -107,6 +107,7 @@ pipeline-stage-view:2.41
 pipeline-utility-steps:3.810.va_7672d206740
 plain-credentials:199.v9f8e1f741799
 plugin-util-api:7.1341.v039f146993d9
+prometheus:856.vc9e3d6e4b_b_9e
 pubsub-light:1.19
 run-condition:276.v97298f3a_cd51
 saml:4.618.v441a_27fa_46d2


### PR DESCRIPTION
## Jira
https://tools.hmcts.net/jira/browse/DTSPO-33801

## What
Adds the [prometheus plugin](https://plugins.jenkins.io/prometheus/) (`856.vc9e3d6e4b_b_9e`) to the controller image. It exposes the metrics already collected by the `metrics` plugin (installed, line 87) in Prometheus format at `/prometheus/`.

## Why
Enables controller health monitoring via the kube-prometheus-stack already running on the Jenkins AKS clusters: build queue depth, executor/agent availability, JVM heap & GC, health-check score, plugin failures. Build/pipeline metrics remain in the existing CosmosDB → dtsse-dashboard-ingestion → Postgres pipeline; this only adds the operational view of the controllers themselves.

## Rollout — please do not merge yet
1. This PR's CI pushes a `pr-<n>-2.564-<run>` image to ACR.
2. That image will be pinned on the SDS **sandbox** Jenkins (ptlsbox, sds-flux-config) with a ServiceMonitor to validate scraping end-to-end.
3. Once validated, the sandbox pin is removed and this PR is merged.

Note: after merge, Renovate automerges the controller tag bump in **both** cnp-flux-config and sds-flux-config (before 6am weekdays), so CNP and SDS controllers will restart with the plugin on the next scheduled morning. The plugin's dependencies (junit, metrics, pipeline-rest-api, commons-lang3-api) are resolved automatically by `jenkins-plugin-cli`.